### PR TITLE
Fixed refresh on color setters, stroke, point size, divider draw first and last

### DIFF
--- a/CustomGauge/src/main/java/pl/pawelkleczkowski/customgauge/CustomGauge.java
+++ b/CustomGauge/src/main/java/pl/pawelkleczkowski/customgauge/CustomGauge.java
@@ -68,8 +68,8 @@ public class CustomGauge extends View {
         int dividerSize = a.getInt(R.styleable.CustomGauge_gaugeDividerSize, 0);
         mDividerColor = a.getColor(R.styleable.CustomGauge_gaugeDividerColor, ContextCompat.getColor(context, android.R.color.white));
         int dividerStep = a.getInt(R.styleable.CustomGauge_gaugeDividerStep, 0);
-        setDividerDrawFirst(a.getBoolean(R.styleable.CustomGauge_gaugeDividerDrawFirst, true));
-        setDividerDrawLast(a.getBoolean(R.styleable.CustomGauge_gaugeDividerDrawLast, true));
+        mDividerDrawFirst = a.getBoolean(R.styleable.CustomGauge_gaugeDividerDrawFirst, true);
+        mDividerDrawLast = a.getBoolean(R.styleable.CustomGauge_gaugeDividerDrawLast, true);
 
         // calculating one point sweep
         mPointAngel = ((double) Math.abs(mSweepAngel) / (mEndValue - mStartValue));
@@ -207,8 +207,6 @@ public class CustomGauge extends View {
 
     public void setSweepAngel(int sweepAngel) {
         mSweepAngel = sweepAngel;
-        mPointAngel = ((double) Math.abs(mSweepAngel) / (mEndValue - mStartValue));
-        invalidate();
     }
 
     @SuppressWarnings("unused")
@@ -277,8 +275,10 @@ public class CustomGauge extends View {
         return mDividerDrawFirst;
     }
 
+    @SuppressWarnings("unused")
     public void setDividerDrawFirst(boolean dividerDrawFirst) {
         mDividerDrawFirst = dividerDrawFirst;
+        invalidate();
     }
 
     @SuppressWarnings("unused")
@@ -286,8 +286,10 @@ public class CustomGauge extends View {
         return mDividerDrawLast;
     }
 
+    @SuppressWarnings("unused")
     public void setDividerDrawLast(boolean dividerDrawLast) {
         mDividerDrawLast = dividerDrawLast;
+        invalidate();
     }
 
 }

--- a/CustomGauge/src/main/java/pl/pawelkleczkowski/customgauge/CustomGauge.java
+++ b/CustomGauge/src/main/java/pl/pawelkleczkowski/customgauge/CustomGauge.java
@@ -60,13 +60,13 @@ public class CustomGauge extends View {
         setEndValue(a.getInt(R.styleable.CustomGauge_gaugeEndValue, 1000));
 
         // pointer size and color
-        setPointSize(a.getInt(R.styleable.CustomGauge_gaugePointSize, 0));
-        setPointStartColor(a.getColor(R.styleable.CustomGauge_gaugePointStartColor, ContextCompat.getColor(context, android.R.color.white)));
-        setPointEndColor(a.getColor(R.styleable.CustomGauge_gaugePointEndColor, ContextCompat.getColor(context, android.R.color.white)));
+        mPointSize = a.getInt(R.styleable.CustomGauge_gaugePointSize, 0);
+        mPointStartColor = a.getColor(R.styleable.CustomGauge_gaugePointStartColor, ContextCompat.getColor(context, android.R.color.white));
+        mPointEndColor = a.getColor(R.styleable.CustomGauge_gaugePointEndColor, ContextCompat.getColor(context, android.R.color.white));
 
         // divider options
         int dividerSize = a.getInt(R.styleable.CustomGauge_gaugeDividerSize, 0);
-        setDividerColor(a.getColor(R.styleable.CustomGauge_gaugeDividerColor, ContextCompat.getColor(context, android.R.color.white)));
+        mDividerColor = a.getColor(R.styleable.CustomGauge_gaugeDividerColor, ContextCompat.getColor(context, android.R.color.white));
         int dividerStep = a.getInt(R.styleable.CustomGauge_gaugeDividerStep, 0);
         setDividerDrawFirst(a.getBoolean(R.styleable.CustomGauge_gaugeDividerDrawFirst, true));
         setDividerDrawLast(a.getBoolean(R.styleable.CustomGauge_gaugeDividerDrawLast, true));
@@ -207,6 +207,8 @@ public class CustomGauge extends View {
 
     public void setSweepAngel(int sweepAngel) {
         mSweepAngel = sweepAngel;
+        mPointAngel = ((double) Math.abs(mSweepAngel) / (mEndValue - mStartValue));
+        invalidate();
     }
 
     @SuppressWarnings("unused")
@@ -234,6 +236,7 @@ public class CustomGauge extends View {
 
     public void setPointSize(int pointSize) {
         mPointSize = pointSize;
+        invalidate();
     }
 
     @SuppressWarnings("unused")
@@ -241,8 +244,10 @@ public class CustomGauge extends View {
         return mPointStartColor;
     }
 
+    @SuppressWarnings("unused")
     public void setPointStartColor(int pointStartColor) {
-        mPointStartColor = pointStartColor;
+        mPointStartColor = ContextCompat.getColor(getContext(), pointStartColor);
+        invalidate();
     }
 
     @SuppressWarnings("unused")
@@ -250,8 +255,10 @@ public class CustomGauge extends View {
         return mPointEndColor;
     }
 
+    @SuppressWarnings("unused")
     public void setPointEndColor(int pointEndColor) {
-        mPointEndColor = pointEndColor;
+        mPointEndColor = ContextCompat.getColor(getContext(), pointEndColor);
+        invalidate();
     }
 
     @SuppressWarnings("unused")
@@ -259,8 +266,10 @@ public class CustomGauge extends View {
         return mDividerColor;
     }
 
+    @SuppressWarnings("unused")
     public void setDividerColor(int dividerColor) {
-        mDividerColor = dividerColor;
+        mDividerColor = ContextCompat.getColor(getContext(), dividerColor);
+        invalidate();
     }
 
     @SuppressWarnings("unused")

--- a/CustomGauge/src/main/java/pl/pawelkleczkowski/customgauge/CustomGauge.java
+++ b/CustomGauge/src/main/java/pl/pawelkleczkowski/customgauge/CustomGauge.java
@@ -47,9 +47,9 @@ public class CustomGauge extends View {
         TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.CustomGauge, 0, 0);
 
         // stroke style
-        setStrokeWidth(a.getDimension(R.styleable.CustomGauge_gaugeStrokeWidth, 10));
-        setStrokeColor(a.getColor(R.styleable.CustomGauge_gaugeStrokeColor, ContextCompat.getColor(context, android.R.color.darker_gray)));
-        setStrokeCap(a.getString(R.styleable.CustomGauge_gaugeStrokeCap));
+        mStrokeWidth = a.getDimension(R.styleable.CustomGauge_gaugeStrokeWidth, 10);
+        mStrokeColor = a.getColor(R.styleable.CustomGauge_gaugeStrokeColor, ContextCompat.getColor(context, android.R.color.darker_gray));
+        mStrokeCap = a.getString(R.styleable.CustomGauge_gaugeStrokeCap);
 
         // angel start and sweep (opposite direction 0, 270, 180, 90)
         setStartAngel(a.getInt(R.styleable.CustomGauge_gaugeStartAngel, 0));
@@ -90,13 +90,7 @@ public class CustomGauge extends View {
         mPaint.setColor(mStrokeColor);
         mPaint.setStrokeWidth(mStrokeWidth);
         mPaint.setAntiAlias(true);
-        if (!TextUtils.isEmpty(mStrokeCap)) {
-            if (mStrokeCap.equals("BUTT"))
-                mPaint.setStrokeCap(Paint.Cap.BUTT);
-            else if (mStrokeCap.equals("ROUND"))
-                mPaint.setStrokeCap(Paint.Cap.ROUND);
-        } else
-            mPaint.setStrokeCap(Paint.Cap.BUTT);
+        setStrokeCap(mStrokeCap, false);
         mPaint.setStyle(Paint.Style.STROKE);
         mRect = new RectF();
 
@@ -169,8 +163,11 @@ public class CustomGauge extends View {
         return mStrokeWidth;
     }
 
+    @SuppressWarnings("unused")
     public void setStrokeWidth(float strokeWidth) {
         mStrokeWidth = strokeWidth;
+        mPaint.setStrokeWidth(mStrokeWidth);
+        invalidate();
     }
 
     @SuppressWarnings("unused")
@@ -178,8 +175,11 @@ public class CustomGauge extends View {
         return mStrokeColor;
     }
 
+    @SuppressWarnings("unused")
     public void setStrokeColor(int strokeColor) {
         mStrokeColor = strokeColor;
+        mPaint.setColor(mStrokeColor);
+        invalidate();
     }
 
     @SuppressWarnings("unused")
@@ -187,8 +187,22 @@ public class CustomGauge extends View {
         return mStrokeCap;
     }
 
+    @SuppressWarnings("unused")
     public void setStrokeCap(String strokeCap) {
+        setStrokeCap(strokeCap, true);
+    }
+
+    private void setStrokeCap(String strokeCap, boolean invalidate) {
         mStrokeCap = strokeCap;
+        if (!TextUtils.isEmpty(mStrokeCap)) {
+            if (mStrokeCap.equals("BUTT"))
+                mPaint.setStrokeCap(Paint.Cap.BUTT);
+            else if (mStrokeCap.equals("ROUND"))
+                mPaint.setStrokeCap(Paint.Cap.ROUND);
+        } else
+            mPaint.setStrokeCap(Paint.Cap.BUTT);
+        if (invalidate)
+            invalidate();
     }
 
     @SuppressWarnings("unused")
@@ -232,6 +246,7 @@ public class CustomGauge extends View {
         return mPointSize;
     }
 
+    @SuppressWarnings("unused")
     public void setPointSize(int pointSize) {
         mPointSize = pointSize;
         invalidate();

--- a/CustomGauge/src/main/java/pl/pawelkleczkowski/customgauge/CustomGauge.java
+++ b/CustomGauge/src/main/java/pl/pawelkleczkowski/customgauge/CustomGauge.java
@@ -177,7 +177,7 @@ public class CustomGauge extends View {
 
     @SuppressWarnings("unused")
     public void setStrokeColor(int strokeColor) {
-        mStrokeColor = strokeColor;
+        mStrokeColor = ContextCompat.getColor(getContext(), strokeColor);;
         mPaint.setColor(mStrokeColor);
         invalidate();
     }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Simple gauge view
 }
 
 <span class="pl-en">dependencies</span> {
-    compile <span class="pl-s"><span class="pl-pds">'</span>pl.pawelkleczkowski.customgauge:CustomGauge:1.0.1<span class="pl-pds">'</span></span>
+    compile <span class="pl-s"><span class="pl-pds">'</span>pl.pawelkleczkowski.customgauge:CustomGauge:1.0.2<span class="pl-pds">'</span></span>
 }</pre></div>
  * Add "pl.pawelkleczkowski.customgauge.CustomGauge" view in your layout (example below)
  * Find CustomGauge view in your activity and use methods "setValue()" and "getValue()" to manage view
@@ -58,16 +58,16 @@ Available view attributes:
         android:paddingLeft="20dp"
         android:paddingRight="20dp"
         android:paddingTop="20dp"
-        gauge:pointStartColor="@color/Red"
-        gauge:pointEndColor="@color/Red"
-        gauge:pointSize="6"
-        gauge:startAngel="135"
-        gauge:strokeCap="ROUND"
-        gauge:strokeColor="@color/Gray"
-        gauge:strokeWidth="10dp"
-        gauge:startValue="0"
-        gauge:endValue="1000"    
-        gauge:sweepAngel="270" />
+        app:gaugePointStartColor="@color/Red"
+        app:gaugePointEndColor="@color/Red"
+        app:gaugePointSize="6"
+        app:gaugeStartAngel="135"
+        app:gaugeStrokeCap="ROUND"
+        app:gaugeStrokeColor="@color/Gray"
+        app:gaugeStrokeWidth="10dp"
+        app:gaugeStartValue="0"
+        app:gaugeEndValue="1000"
+        app:gaugeSweepAngel="270" />
 
     <pl.pawelkleczkowski.customgauge.CustomGauge
         android:id="@+id/gauge2"
@@ -79,15 +79,15 @@ Available view attributes:
         android:paddingLeft="10dp"
         android:paddingRight="10dp"
         android:paddingTop="10dp"
-        gauge:endValue="800"
-        gauge:pointEndColor="@color/DarkBlue"
-        gauge:pointStartColor="@color/LightSkyBlue"
-        gauge:startAngel="135"
-        gauge:startValue="200"
-        gauge:strokeCap="ROUND"
-        gauge:strokeColor="@color/Gray"
-        gauge:strokeWidth="10dp"
-        gauge:sweepAngel="270" />
+        app:gaugeEndValue="800"
+        app:gaugePointEndColor="@color/DarkBlue"
+        app:gaugePointStartColor="@color/LightSkyBlue"
+        app:gaugeStartAngel="135"
+        app:gaugeStartValue="200"
+        app:gaugeStrokeCap="ROUND"
+        app:gaugeStrokeColor="@color/Gray"
+        app:gaugeStrokeWidth="10dp"
+        app:gaugeSweepAngel="270" />
 
 &nbsp;
 


### PR DESCRIPTION
With this pull request those setters will refresh their value on the fly:
- setStrokeWidth
- setStrokeColor
- setStrokeCap
- setPointSize
- setPointStartColor
- setPointEndColor
- setDividerColor
- setDividerDrawFirst
- setDividerDrawLast

Those setters must be fixed:
- setStartAngel
- setSweepAngel
- setStartValue
- setEndValue

Those setters must be implemented:
- setDividerSize
- setDividerStep
