### PR TITLE
Fix problems when layoutparams are match_parent

### DIFF
--- a/CustomGauge/src/main/java/pl/pawelkleczkowski/customgauge/CustomGauge.java
+++ b/CustomGauge/src/main/java/pl/pawelkleczkowski/customgauge/CustomGauge.java
@@ -1,5 +1,3 @@
-package pl.pawelkleczkowski.customgauge;
-
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
@@ -11,6 +9,8 @@ import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
+
+import com.grupoarelance.brisa.R;
 
 public class CustomGauge extends View {
 
@@ -107,18 +107,19 @@ public class CustomGauge extends View {
     @Override
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
-        float paddingLeft = getPaddingLeft();
-        float paddingRight= getPaddingRight();
-        float paddingTop = getPaddingTop();
-        float paddingBottom = getPaddingBottom();
-        float width = getWidth() - (paddingLeft+paddingRight);
-        float height = getHeight() - (paddingTop+paddingBottom);
-        float radius = (width > height ? width/2 : height/2);
+        float padding = getStrokeWidth();
+        float size = getWidth()<getHeight() ? getWidth() : getHeight();
+        float width = size - (2*padding);
+        float height = size - (2*padding);
+//        float radius = (width > height ? width/2 : height/2);
+        float radius = (width < height ? width/2 : height/2);
 
-        float rectLeft = width/2 - radius + paddingLeft;
-        float rectTop = height/2 - radius + paddingTop;
-        float rectRight = width/2 - radius + paddingLeft + width;
-        float rectBottom = height/2 - radius + paddingTop + height;
+
+
+        float rectLeft = (getWidth() - (2*padding))/2 - radius + padding;
+        float rectTop = (getHeight() - (2*padding))/2 - radius + padding;
+        float rectRight = (getWidth() - (2*padding))/2 - radius + padding + width;
+        float rectBottom = (getHeight() - (2*padding))/2 - radius + padding + height;
 
         mRect.set(rectLeft, rectTop, rectRight, rectBottom);
 

--- a/CustomGauge/src/main/java/pl/pawelkleczkowski/customgauge/CustomGauge.java
+++ b/CustomGauge/src/main/java/pl/pawelkleczkowski/customgauge/CustomGauge.java
@@ -1,3 +1,5 @@
+package pl.pawelkleczkowski.customgauge;
+
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
@@ -9,8 +11,6 @@ import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
-
-import com.grupoarelance.brisa.R;
 
 public class CustomGauge extends View {
 


### PR DESCRIPTION
I saw some problems with the component when I adjust weight and height as match_parent, because the gauge isn't at center of the view and some parts it's out of bound.

I've make some changes in the code to solve it.
