### PR TITLE
Delete backup property from library Manifest

### DIFF
--- a/CustomGauge/src/main/AndroidManifest.xml
+++ b/CustomGauge/src/main/AndroidManifest.xml
@@ -2,10 +2,8 @@
     package="pl.pawelkleczkowski.customgauge">
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true">
-
     </application>
 
 </manifest>


### PR DESCRIPTION
The decision of allowing automatic backups of the application data is completely out of the scope of the library. 
Its presence causes conflicts when the app developer wants to deactivate it.